### PR TITLE
fix(ci): simplify GitHub secrets access check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,19 +109,19 @@ jobs:
           cargo llvm-cov test cloud_ --no-report --features rustls-tls -- --nocapture
           cargo llvm-cov test https_errors --no-report -- --nocapture
 
-      - name: Generate code coverage
-        run: cargo llvm-cov report --codecov --output-path codecov.json
+      # - name: Generate code coverage
+      #   run: cargo llvm-cov report --codecov --output-path codecov.json
 
       # Similarly to the Cloud tests, we skip coverage upload for community PRs, 
       # as they won't have access to the Codecov token.
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        if: steps.check-secrets-access.outputs.has-access == 'true'
-        with:
-          files: codecov.json
-          token: ${{ secrets.CODECOV_TOKEN }}
-          slug: ClickHouse/adbc_clickhouse
-          fail_ci_if_error: true
+      # - name: Upload coverage to Codecov
+      #   uses: codecov/codecov-action@v5
+      #   if: steps.check-secrets-access.outputs.has-access == 'true'
+      #   with:
+      #     files: codecov.json
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     slug: ClickHouse/adbc_clickhouse
+      #     fail_ci_if_error: true
 
   miri:
     needs: build


### PR DESCRIPTION
A simpler check for GitHub Secrets access; perhaps it can be backported to https://github.com/ClickHouse/clickhouse-rs later, if it works.

Since there is no Codecov integration with this repo yet, I disabled the related steps.