### PR TITLE
feat: release `0.1.0-alpha.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "adbc_clickhouse"
-version = "0.0.1"
+version = "0.1.0-alpha.1"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adbc_clickhouse"
-version = "0.0.1"
+version = "0.1.0-alpha.1"
 edition = "2024"
 description = "Official ClickHouse ADBC driver."
 authors = [

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright 2025 ClickHouse, LLC.
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -56,9 +56,6 @@ The driver DLL must be available in the dynamic link search path for your platfo
 
 [Cargo]: https://doc.rust-lang.org/cargo/index.html
 
-
-
-
 ### Feature Flags
 
 #### ADBC Driver Manager Integration

--- a/README.md
+++ b/README.md
@@ -7,9 +7,87 @@ Implemented using the [official ClickHouse client for Rust](https://clickhouse.c
 ## Note: Work-in-Progress
 This driver is still under active development and should not be considered ready for production use.
 
-## Feature Flags
+Many methods are stubbed out and return `NotImplemented` errors.
 
-### TLS Support
+However, the core query flow is supported:
 
-This package exposes the same TLS features as 
-[the `clickhouse` crate it uses under the hood](https://github.com/ClickHouse/clickhouse-rs?tab=readme-ov-file#tls).
+* Creating a `Driver` and `Database`
+* Setting URL, username and password on the `Database`
+* Creating a `Connection` and `Statement`
+* Setting a query with `Statement::set_sql_query()` and binding parameters with `Statement::bind()`
+* Binding a statement in streaming insert mode with `Statement::bind_params()`
+* Executing a statement with `Statement::execute()` or `Statement::execute_update()`
+
+## Usage
+
+### ADBC Driver Manager
+
+Binary builds of the driver are pending.
+
+It may be built from source using Rust 1.91 or newer and [Cargo], Rust's first-party build tool and package manager.
+
+After installing or updating Rust, clone this repository and then choose one of the following `cargo build` commands
+(refer to the feature descriptions below when customizing):
+
+* Build with Native TLS support (OpenSSL on Linux, Secure Transport on macOS, SChannel on Windows):
+```
+cargo build --release --features ffi,native-tls
+```
+
+* Build with Rustls and `aws-lc` and the native TLS root certificate store for the platform:
+```
+cargo build --release --features ffi,rustls-tls
+```
+
+* Build without TLS support (the `ffi` feature is required for use with a driver manager):
+```
+cargo build --release --features ffi
+```
+
+When finished, the driver dynamic-link library (DLL) can be found under `target/release` with the conventional name and 
+extension for your platform:
+
+* Linux, BSDs: `libadbc_clickhouse.so`
+* macOS: `libadbc_clickhouse.dylib`
+* Windows: `adbc_clickhouse.dll`
+
+If the driver manager has the option to load the driver by name, pass `adbc_clickhouse` instead of the DLL filename.
+The driver DLL must be available in the dynamic link search path for your platform.
+
+[Cargo]: https://doc.rust-lang.org/cargo/index.html
+
+
+
+
+### Feature Flags
+
+#### ADBC Driver Manager Integration
+
+When the `ffi` feature is enabled, this crate exports the `AdbcDriverInit()` and `AdbcClickhouseInit()` functions.
+
+It then may be built as a dynamic library and loaded by an [ADBC driver manager][adbc-driver].
+
+[adbc-driver]: https://arrow.apache.org/adbc/current/format/how_manager.html
+
+#### TLS Support
+
+This package exposes the same Transport Layer Security (TLS) features as
+[the `clickhouse` crate](https://github.com/ClickHouse/clickhouse-rs?tab=readme-ov-file#tls) it uses under the hood:
+
+* `native-tls`: use the native TLS implementation for the platform
+  * OpenSSL on Linux
+  * SChannel on Windows
+  * Secure Transport on macOS
+* `rustls-tls`: enables both `rustls-tls-aws-lc` and `rustls-tls-webpki-roots`
+* `rustls-tls-aws-lc`: use [Rustls] with the [`aws-lc`] cryptography provider
+* `rustls-tls-ring`: use [Rustls] with the [`ring`] cryptography provider
+* `rustls-tls-native-roots`: configure [Rustls] to use the native TLS root certificate store for the platform
+* `rustls-tls-webpki-roots`: configure [Rustls] to use a statically compiled set of TLS roots ([`webpki-roots`] crate)
+
+Note that Rustls has no TLS roots by default; when using the `rustls-tls-aws-lc` or `rustls-tls-ring` features,
+you should also enable either `rustls-tls-native-roots` or `rustls-tls-webpki-roots` to choose a TLS root store.
+
+[Rustls]: https://github.com/rustls/rustls
+[`aws-lc`]: https://github.com/aws/aws-lc-rs
+[`ring`]: https://github.com/briansmith/ring
+[`webpki-roots`]: https://github.com/rustls/webpki-roots

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ The official ClickHouse driver for [Arrow Database Connectivity (ADBC)](https://
 
 Implemented using the [official ClickHouse client for Rust](https://clickhouse.com/docs/integrations/rust).
 
-Connects using the [ClickHouse HTTP  interface](https://clickhouse.com/docs/interfaces/http#overview).
+Connects using the [ClickHouse HTTP interface][ch-http].
+
+[ch-http]: https://clickhouse.com/docs/interfaces/http#overview
 
 ## Note: Work-in-Progress
 This driver is still under active development and should not be considered ready for production use.
@@ -75,6 +77,9 @@ The driver DLL can then be loaded by path or by name (assuming it is on the sear
 using the driver manager API.
 
 See [the ADBC documentation for your client language](https://arrow.apache.org/adbc/main/index.html) for details.
+
+Because this driver uses the [ClickHouse HTTP interface][ch-http], the database URI (`ADBC_OPTION_URI` in `adbc.h`)
+should use the `http://` or `https://` schemes.
 
 ### Rust API
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ However, the core query flow is supported:
 * Setting URL, username and password on the `Database`
 * Creating a `Connection` and `Statement`
 * Setting a query with `Statement::set_sql_query()` and binding parameters with `Statement::bind()`
-* Binding a statement in streaming insert mode with `Statement::bind_params()`
+* Binding a statement in streaming insert mode with `Statement::bind_stream()`
 * Executing a statement with `Statement::execute()` or `Statement::execute_update()`
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -88,3 +88,38 @@ you should also enable either `rustls-tls-native-roots` or `rustls-tls-webpki-ro
 [`aws-lc`]: https://github.com/aws/aws-lc-rs
 [`ring`]: https://github.com/briansmith/ring
 [`webpki-roots`]: https://github.com/rustls/webpki-roots
+
+## Support Policies
+
+This project adopts the same support policies as the [ClickHouse Rust client](https://github.com/ClickHouse/clickhouse-rs/tree/main?tab=readme-ov-file#support-policies).
+
+### Minimum Supported Rust Version (MSRV)
+
+This project's MSRV is the second-to-last stable release as of the beginning of the current release cycle (`0.x.0`),
+where it will remain until the beginning of the _next_ release cycle (`0.{x+1}.0`).
+
+The MSRV for the `0.1.0` release cycle is `1.91.0`.
+
+This guarantees that `adbc_clickhouse` will compile with a Rust version that is at _least_ six weeks old,
+which should be plenty of time for it to make it through any packaging system that is being actively kept up to date.
+
+Beware when installing Rust through operating system package managers, as it can often be a year or more
+out-of-date. For example, Debian Bookworm (released 10 June 2023) shipped with Rust 1.63.0 (released 11 August 2022).
+
+### ClickHouse Versions
+
+The supported versions of the ClickHouse database server coincide with the versions currently receiving security
+updates.
+
+For the list of currently supported versions, see <https://github.com/ClickHouse/ClickHouse/blob/master/SECURITY.md#security-change-log-and-support>.
+
+## License
+
+Licensed under either of
+
+-   Apache License, Version 2.0
+    ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+-   MIT license
+    ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,10 @@ mod schema;
 mod statement;
 mod writer;
 
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+pub mod readme_test {}
+
 // `adbc_core::error::Result` doesn't support overriding the error type
 // so it's hazardous to import directly
 pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,8 +194,6 @@ impl Driver for ClickhouseDriver {
 }
 
 /// ClickHouse ADBC [`Database`] implementation.
-///
-///
 pub struct ClickhouseDatabase {
     tokio: Option<TokioContext>,
     uri: Option<String>,

--- a/src/options.rs
+++ b/src/options.rs
@@ -7,7 +7,10 @@ use std::ops::Range;
 use std::str::FromStr;
 
 #[cfg(doc)]
-use adbc_core::{Database, Optionable};
+use {
+    crate::{ClickhouseConnection, ClickhouseDatabase, ClickhouseStatement},
+    adbc_core::{Database, Optionable},
+};
 
 /// Product info string to include in ClickHouse API calls.
 ///
@@ -24,9 +27,9 @@ use adbc_core::{Database, Optionable};
 /// as well as the underlying ClickHouse Rust client version.
 ///
 /// This option may be set at any level of the object hierarchy:
-/// * `Database`
-/// * `Connection`
-/// * `Statement`
+/// * [`ClickhouseDatabase`]
+/// * [`ClickhouseConnection`]
+/// * [`ClickhouseStatement`]
 ///
 /// The set value will propagate to any newly created objects lower in the hierarchy.
 ///

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,13 +1,21 @@
+//! Keys for setting options on various ClickHouse ADBC objects.
+
 use adbc_core::error::{Error, Status};
 use adbc_core::options::OptionValue;
 use std::fmt::{Display, Formatter};
 use std::ops::Range;
 use std::str::FromStr;
 
+#[cfg(doc)]
+use adbc_core::{Database, Optionable};
+
 /// Product info string to include in ClickHouse API calls.
 ///
 /// This will be added to the `User-Agent` header when invoking the ClickHouse HTTP API,
-/// which is useful for metrics.
+/// which is useful for identification in query logs
+/// (`http_user_agent` in the [`system.query_log`] view) and capture of metrics.
+///
+/// [`system.query_log`]: https://clickhouse.com/docs/operations/system-tables/query_log#columns
 ///
 /// The expected format of the string is `<product name>/<product version>`
 /// with multiple product name/version pairs separated by spaces.
@@ -63,6 +71,23 @@ use std::str::FromStr;
 /// ).unwrap();
 /// ```
 pub const PRODUCT_INFO: &str = "clickhouse.client.product_info";
+
+/// Session ID string to use with the [ClickHouse HTTP interface][http-session_id].
+///
+/// This session ID is used to persist any shared state between statements, such as [settings]
+/// and [temporary tables]. By default, session state persists for 60 seconds.
+///
+/// May be set on `ClickhouseConnection` or `ClickhouseStatement`.
+///
+/// When a `ClickhouseConnection` is created, a random session ID is generated if one is not passed
+/// in via [`Database::new_connection_with_opts()`].
+///
+/// It may be read back with [`Optionable::get_option_string()`].
+///
+/// [http-session_id]: https://clickhouse.com/docs/interfaces/http#using-clickhouse-sessions-in-the-http-protocol
+/// [settings]: https://clickhouse.com/docs/sql-reference/statements/set
+/// [temporary tables]: https://clickhouse.com/docs/sql-reference/statements/create/table#temporary-tables
+pub const SESSION_ID: &str = "clickhouse.client.session_id";
 
 /// ID string for the current query for explicit cancellation and identification in query logs.
 ///
@@ -202,12 +227,26 @@ impl TryFrom<OptionValue> for ProductInfo {
     type Error = Error;
 
     fn try_from(value: OptionValue) -> Result<Self, Self::Error> {
-        match value {
-            OptionValue::String(s) => s.parse(),
-            other => Err(Error::with_message_and_status(
-                format!("option {PRODUCT_INFO:?} must be a string; got: {other:?}"),
+        value.try_string(PRODUCT_INFO)?.parse()
+    }
+}
+
+pub(crate) trait OptionValueExt {
+    fn try_string(self, key: impl AsRef<str>) -> Result<String, Error>;
+}
+
+impl OptionValueExt for OptionValue {
+    fn try_string(self, key: impl AsRef<str>) -> Result<String, Error> {
+        if let Self::String(s) = self {
+            Ok(s)
+        } else {
+            Err(Error::with_message_and_status(
+                format!(
+                    "expected string for option {:?}, got {self:?}",
+                    key.as_ref()
+                ),
                 Status::InvalidArguments,
-            )),
+            ))
         }
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -106,7 +106,7 @@ pub const SESSION_ID: &str = "clickhouse.client.session_id";
 ///
 /// use adbc_core::{Driver, Database, Connection, Statement, Optionable};
 ///
-/// let driver = ClickhouseDriver::init();
+/// let mut driver = ClickhouseDriver::init();
 ///
 /// let db = driver.new_database().unwrap();
 /// let mut conn = db.new_connection().unwrap();

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -29,7 +29,7 @@ use crate::{AugmentedClient, Result, TokioContext, options, random_id};
 ///
 /// [Query parameters] are supported using [`Self::bind()`] to bind a single `RecordBatch`.
 ///
-/// Streaming inserts are supported with [`Self::bind_batch()`] and [`Self::execute_update()`].
+/// Streaming inserts are supported with [`Self::bind_stream()`] and [`Self::execute_update()`].
 /// For streaming inserts, the SQL query must be of the form `INSERT INTO ... FORMAT ArrowStream`.
 pub struct ClickhouseStatement {
     client: AugmentedClient,

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -343,9 +343,8 @@ fn bind_scalar(query: Query, name: &str, array: &dyn Array) -> Result<Query, Err
                 )
             })?;
 
-            // Needs to be explicitly serialized as UTC, otherwise it might be assumed to be
-            // in the server's or column's set time zone.
-            Ok(query.param(name, datetime.and_utc()))
+            // FIXME: we have no way to ensure timestamps are interpreted with the correct time zone
+            Ok(query.param(name, datetime))
         }
         DataType::Date32 => Ok(query.param(
             name,

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -20,6 +20,9 @@ use crate::options::OptionValueExt;
 use crate::writer::ArrowStreamWriter;
 use crate::{AugmentedClient, Result, TokioContext, options, random_id};
 
+/// ClickHouse ADBC [`Statement`] implementation.
+///
+/// This inherits the session ID of the parent [`ClickhouseConnection`][super::ClickhouseConnection].
 pub struct ClickhouseStatement {
     client: AugmentedClient,
     tokio: TokioContext,

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -399,6 +399,9 @@ fn bind_scalar(query: Query, name: &str, array: &dyn Array) -> Result<Query, Err
 
             // FIXME: we have no way to ensure timestamps are interpreted with the correct time zone
             // https://github.com/ClickHouse/ClickHouse/issues/95913
+            //
+            // To match the server behavior, we should serialize timestamps with a timezone as UTC,
+            // and serialize them as naive otherwise: https://github.com/ClickHouse/ClickHouse/blob/db27d85fb2d2fa137d531d08dff13109a86cead5/src/Processors/Formats/Impl/ArrowColumnToCHColumn.cpp#L402-L406
             Ok(query.param(name, datetime))
         }
         DataType::Date32 => Ok(query.param(


### PR DESCRIPTION
## Summary

This PR represents the `0.1.0-alpha.1` release of `adbc_clickhouse`.

Not everything is implemented, but the core query flow should be supported. See the README in the diff for details.

closes #2
closes #37

## Checklist
Delete items not relevant to your PR:
- [x] Add MIT/Apache-2.0 license files
- [x] https://github.com/ClickHouse/adbc_clickhouse/issues/37
- [x] https://github.com/ClickHouse/adbc_clickhouse/issues/2
- [x] Integration test for `options::SESSION_ID`